### PR TITLE
Add custom date_worked and notes functionality

### DIFF
--- a/timesync
+++ b/timesync
@@ -20,7 +20,7 @@ if __name__ == '__main__':
         while(input('More activities? [y/n] ') == 'y'):
             activities.append(input('Activity: '))
 
-        duration = int(input('Time worked in minutes: '))
+        duration = int(input('Time worked in seconds: '))
         issue_uri = input('Issue uri: ') or None
         d = datetime.datetime.now()
         date_worked = "{}-{}-{}".format(d.year, d.month, d.day)

--- a/timesync
+++ b/timesync
@@ -22,10 +22,21 @@ if __name__ == '__main__':
 
         duration = int(input('Time worked in seconds: '))
         issue_uri = input('Issue uri: ') or None
-        d = datetime.datetime.now()
-        date_worked = "{}-{}-{}".format(d.year, d.month, d.day)
 
-        # can't choose a custom date or note, sorry
+        d = datetime.datetime.now()
+        month_worked = input('Month worked (format: 01): ')
+        day_worked = input('Day worked (format: 31): ')
+        year_worked = d.year
+
+        if month_worked is None:
+            month_worked = d.month
+
+        if day_worked is None:
+            day_worked = d.day
+
+        date_worked = "{}-{}-{}".format(year_worked, month_worked, day_worked)
+
+        # can't choose a custom note, sorry
         # pull requests welcome
 
         url = "{}/v1/times".format(config['server'])

--- a/timesync
+++ b/timesync
@@ -28,16 +28,17 @@ if __name__ == '__main__':
         day_worked = input('Day worked (format: 31): ')
         year_worked = d.year
 
-        if month_worked is None:
+        if month_worked is "":
             month_worked = d.month
 
-        if day_worked is None:
+        if day_worked is "":
             day_worked = d.day
 
         date_worked = "{}-{}-{}".format(year_worked, month_worked, day_worked)
 
         # can't choose a custom note, sorry
         # pull requests welcome
+        note = input('Note: ')
 
         url = "{}/v1/times".format(config['server'])
         values = {
@@ -51,7 +52,8 @@ if __name__ == '__main__':
                 'project': project,
                 'activities': activities,
                 'issue_uri': issue_uri,
-                'date_worked': date_worked
+                'date_worked': date_worked,
+                'notes': note
             }
         }
 

--- a/timesync
+++ b/timesync
@@ -36,8 +36,6 @@ if __name__ == '__main__':
 
         date_worked = "{}-{}-{}".format(year_worked, month_worked, day_worked)
 
-        # can't choose a custom note, sorry
-        # pull requests welcome
         note = input('Note: ')
 
         url = "{}/v1/times".format(config['server'])


### PR DESCRIPTION
If nothing is entered for month or day, the default is today. Year is always the current year for now.

I tested this with time entries 15, 16, 17, 18, and 19 at http://aqua.workstation.osuosl.bak:3000/v1/times 

 15) Month and day provided by user
 16) Only month provided by user
 17) Only day provided by user
 18) Month and day not provided by user
 19) No note provided by user
